### PR TITLE
Fix typo in GameBase

### DIFF
--- a/src/JamTemplate/common/GameBase.cpp
+++ b/src/JamTemplate/common/GameBase.cpp
@@ -27,7 +27,7 @@ void GameBase::switchState(std::shared_ptr<GameState> newState)
     }
 }
 
-std::shared_ptr<GameState> GameBase::getCurrentSate()
+std::shared_ptr<GameState> GameBase::getCurrentState()
 {
     if (m_nextState == nullptr) {
         return m_state;

--- a/src/JamTemplate/common/GameBase.hpp
+++ b/src/JamTemplate/common/GameBase.hpp
@@ -25,7 +25,7 @@ public:
     // doSwitchState() which will happen at the beginning of the next update loop.
     void switchState(std::shared_ptr<GameState> newState) override;
 
-    std::shared_ptr<GameState> getCurrentSate() override;
+    std::shared_ptr<GameState> getCurrentState() override;
 
     void run() override;
 

--- a/src/JamTemplate/common/GameLoopInterface.hpp
+++ b/src/JamTemplate/common/GameLoopInterface.hpp
@@ -15,7 +15,7 @@ public:
     // doSwitchState() which will happen at the beginning of the next update loop.
     virtual void switchState(std::shared_ptr<GameState> newState) = 0;
 
-    virtual std::shared_ptr<GameState> getCurrentSate() = 0;
+    virtual std::shared_ptr<GameState> getCurrentState() = 0;
 
     virtual void run() = 0;
     virtual void startGame(

--- a/src/UnitTests/GameTest.cpp
+++ b/src/UnitTests/GameTest.cpp
@@ -103,19 +103,19 @@ TEST_F(GameTest, SetRenderTargetInvalid)
     EXPECT_THROW(g->setRenderTarget(nullptr), std::invalid_argument);
 }
 
-TEST_F(GameTest, GetCurrentStateNullptr) { EXPECT_EQ(g->getCurrentSate(), nullptr); }
+TEST_F(GameTest, GetCurrentStateNullptr) { EXPECT_EQ(g->getCurrentState(), nullptr); }
 
 TEST_F(GameTest, GetCurrentStateNonNullptr)
 {
     g->switchState(std::make_shared<NiceMock<MockState>>());
-    EXPECT_NE(g->getCurrentSate(), nullptr);
+    EXPECT_NE(g->getCurrentState(), nullptr);
 }
 
 TEST_F(GameTest, GetCurrentStateAfterSwitch)
 {
     g->switchState(std::make_shared<NiceMock<MockState>>());
     EXPECT_NO_THROW(g->run());
-    EXPECT_NE(g->getCurrentSate(), nullptr);
+    EXPECT_NE(g->getCurrentState(), nullptr);
 }
 
 TEST_F(GameTest, RunWithOutState) { EXPECT_NO_THROW(g->run()); }

--- a/src/UnitTests/MockGame.hpp
+++ b/src/UnitTests/MockGame.hpp
@@ -16,7 +16,7 @@ public:
     MOCK_METHOD(std::shared_ptr<jt::renderTarget>, getRenderTarget, (), (const, override));
 
     MOCK_METHOD(void, switchState, (std::shared_ptr<jt::GameState>), (override));
-    MOCK_METHOD(std::shared_ptr<jt::GameState>, getCurrentSate, (), (override));
+    MOCK_METHOD(std::shared_ptr<jt::GameState>, getCurrentState, (), (override));
 
     MOCK_METHOD(void, run, (), (override));
     MOCK_METHOD(void, startGame,


### PR DESCRIPTION
Fix typo in GameBase function: getCurrentSate→getCurrentState